### PR TITLE
test: add bin-entries regression guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsx src/index.ts",
+    "pretest": "npm run build",
     "test": "node --experimental-vm-modules node_modules/.bin/jest",
     "test:coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
     "lint": "eslint src/",

--- a/tests/bin-entries.test.ts
+++ b/tests/bin-entries.test.ts
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = process.cwd();
+const pkg = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf-8')) as {
+  name: string;
+  bin?: string | Record<string, string>;
+  files?: string[];
+};
+
+function normalizeBin(bin: typeof pkg.bin, name: string): Array<[string, string]> {
+  if (typeof bin === 'string') return [[name, bin]];
+  if (bin && typeof bin === 'object') return Object.entries(bin);
+  return [];
+}
+
+function pkgFilesCoversPath(files: string[], relPath: string): boolean {
+  const clean = relPath.replace(/^\.\//, '');
+  const top = clean.split('/')[0];
+  return files.some((f) => {
+    const c = f.replace(/\/$/, '').replace(/^\.\//, '');
+    return c === top;
+  });
+}
+
+describe('package.json bin entries', () => {
+  const entries = normalizeBin(pkg.bin, pkg.name);
+  const files: string[] = pkg.files ?? [];
+
+  it('declares at least one bin entry', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" exists on disk', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    expect(existsSync(abs)).toBe(true);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" starts with a node shebang', (_name, rel) => {
+    const abs = join(repoRoot, rel.replace(/^\.\//, ''));
+    if (!existsSync(abs)) return;
+    const firstLine = readFileSync(abs, 'utf-8').split('\n', 1)[0] ?? '';
+    expect(firstLine).toMatch(/^#!.*\bnode\b/);
+  });
+
+  it.each(entries)('bin "%s" -> "%s" lives under a directory in pkg.files', (_name, rel) => {
+    expect(pkgFilesCoversPath(files, rel)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a parameterised Jest test suite that validates all `package.json` bin entries:
- Target file exists on disk
- Target starts with a node shebang (`#!/usr/bin/env node`)  
- Target lives under a directory declared in `pkg.files`

## Why This Matters

Forge-Space/core shipped v1.4.0 through v1.14.0 with `bin.forge-patterns` pointing at a non-existent `dist/cli.js` file — an error that went undetected for over a year because there was no regression guard. Every `npx @forgespace/core forge-patterns` invocation failed silently.

See [Forge-Space/core#202](https://github.com/Forge-Space/core/pull/202) for the original incident and test implementation.

## Test Plan

- [x] Build runs successfully before test (`npm run build`)
- [x] Test file matches Jest pattern (`**/tests/**/*.test.ts`)
- [x] 4 test cases pass: 1 "has bin entry" + 3 assertions per entry
- [x] Mutation test: reverting `bin.forge-ai-init` to non-existent path → test fails on existence assertion
- [x] Original `bin.forge-ai-init` -> `./dist/index.js` restored → all tests pass

## Notes

This PR references [Forge-Space/core#202](https://github.com/Forge-Space/core/pull/202) as the pattern implementation source. Rolling out to all Forge Space npm packages with `bin` blocks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test suite validating package bin declarations, confirming executable files exist, contain proper Node.js shebangs, and reference correct file paths.
* **Chores**
  * Ensure the project is built automatically before running the test suite by adding a pre-test build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->